### PR TITLE
ci: replace cypress/install job with a quicker validate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,38 +4,29 @@ orbs:
   cypress: cypress-io/cypress@1.7.0
 
 jobs:
-  release:
-    docker:
-      - image: circleci/node:lts
-    working_directory: ~/repo
+  validate:
+    executor: cypress/base-10
     steps:
-      - checkout
-      - restore_cache:
-          name: Restore Yarn Package Cache
-          keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
-      - run:
-          name: Install Dependencies
-          command: yarn install --frozen-lockfile
-      - save_cache:
-          name: Save Yarn Package Cache
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache
+      - attach_workspace:
+          at: ~/
+      - run: yarn validate
+  release:
+    executor: cypress/base-10
+    steps:
+      - attach_workspace:
+          at: ~/
       - run: yarn semantic-release
 
 workflows:
   build:
     jobs:
-      - cypress/install:
-          yarn: true
-          build: yarn validate
       - cypress/run:
-          requires:
-            - cypress/install
           yarn: true
           start: yarn serve
           wait-on: '--timeout 60000 http://localhost:8000'
-      - release:
+      - validate:
           requires:
             - cypress/run
+      - release:
+          requires:
+            - validate


### PR DESCRIPTION
The install job seems to be a part of cypress/run anyway, so...?