### PR TITLE
revert: build(ts): enable skipLibCheck hack to avoid issues with Cypress types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,7 @@
     "noEmit": true,
     "strict": true,
     "types": ["cypress", "@testing-library/cypress", "cypress-axe"],
-    "typeRoots": ["node_modules/@types", "./src/@types"],
-    // TODO: remove once Cypress types are sorted out
-    "skipLibCheck": true
+    "typeRoots": ["node_modules/@types", "./src/@types"]
   },
   "exclude": [".cache", "public"]
 }


### PR DESCRIPTION
This reverts commit 815c45d33a43ba3ac93a293154bf82fbea748598.