### PR TITLE
refactor: migrate font from Source Sans Pro to Source Sans 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "7.22.5",
         "@babel/plugin-syntax-jsx": "7.22.5",
-        "@fontsource/source-sans-pro": "5.0.3",
+        "@fontsource/source-sans-3": "5.0.3",
         "@semantic-release/git": "10.0.1",
         "@testing-library/cypress": "9.0.0",
         "@types/node": "18.16.19",
@@ -2065,10 +2065,10 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@fontsource/source-sans-pro": {
+    "node_modules/@fontsource/source-sans-3": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-5.0.3.tgz",
-      "integrity": "sha512-mQnjuif/37VxwRloHZ+wQdoozd2VPWutbFSt1AuSkk7nFXIBQxHJLw80rgCF/osL0t7N/3Gx1V7UJuOX2zxzhQ=="
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-3/-/source-sans-3-5.0.3.tgz",
+      "integrity": "sha512-5oQh3zLBiWpv2v50X2cq1iqJ2LG9M6XjGdWZJHs8LYfUFj+YenK5LzSE7sx9p4NFMtZFSNQAsc8CKdHHxzMXjA=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -16709,10 +16709,10 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
       "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw=="
     },
-    "@fontsource/source-sans-pro": {
+    "@fontsource/source-sans-3": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-5.0.3.tgz",
-      "integrity": "sha512-mQnjuif/37VxwRloHZ+wQdoozd2VPWutbFSt1AuSkk7nFXIBQxHJLw80rgCF/osL0t7N/3Gx1V7UJuOX2zxzhQ=="
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-3/-/source-sans-3-5.0.3.tgz",
+      "integrity": "sha512-5oQh3zLBiWpv2v50X2cq1iqJ2LG9M6XjGdWZJHs8LYfUFj+YenK5LzSE7sx9p4NFMtZFSNQAsc8CKdHHxzMXjA=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@babel/core": "7.22.5",
     "@babel/plugin-syntax-jsx": "7.22.5",
-    "@fontsource/source-sans-pro": "5.0.3",
+    "@fontsource/source-sans-3": "5.0.3",
     "@semantic-release/git": "10.0.1",
     "@testing-library/cypress": "9.0.0",
     "@types/node": "18.16.19",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,6 @@
-import '@fontsource/source-sans-pro/latin-200.css';
-import '@fontsource/source-sans-pro/latin-400.css';
-import '@fontsource/source-sans-pro/latin-600.css';
+import '@fontsource/source-sans-3/latin-200.css';
+import '@fontsource/source-sans-3/latin-400.css';
+import '@fontsource/source-sans-3/latin-600.css';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { Routes, Route } from 'react-router-dom';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Source Sans Pro', ...defaultTheme.fontFamily.sans],
+        sans: ['"Source Sans 3"', ...defaultTheme.fontFamily.sans],
       },
       colors: {
         tipsy: '#8d6c9f',


### PR DESCRIPTION
Source Sans Pro seems to have been replaced with Source Sans 3 in the Google Fonts directory. I can only assume SSP is deprecated or something.