### PR TITLE
refactor: use native subpath imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "tipsy",
+  "private": true,
   "version": "2.1.1",
   "description": "A simple tip calculator and bill divider PWA",
   "type": "module",
+  "imports": {
+    "#/*": "./*"
+  },
   "author": {
     "name": "Justin Hall",
     "email": "justin.r.hall@gmail.com"
@@ -27,7 +31,6 @@
     "test:e2e:run": "cross-env CI=true playwright test",
     "typecheck": "tsc"
   },
-  "private": true,
   "packageManager": "pnpm@10.28.0",
   "dependencies": {
     "@fontsource/source-sans-3": "5.2.9",

--- a/src/core/footer.tsx
+++ b/src/core/footer.tsx
@@ -1,5 +1,5 @@
 import { useMatch } from 'react-router';
-import { Icon } from '../icons/icon';
+import { Icon } from '#/src/icons/icon';
 
 export function Footer() {
   const onHomePage = useMatch({ path: '/', end: true });

--- a/src/core/header.tsx
+++ b/src/core/header.tsx
@@ -1,7 +1,7 @@
 import { Link, useMatch } from 'react-router';
 import currency from 'currency.js';
-import { Icon } from '../icons/icon';
-import { billFromUrlParam } from '../utils';
+import { Icon } from '#/src/icons/icon';
+import { billFromUrlParam } from '#/src/utils';
 
 export function Header() {
   const settingsMatch = useMatch('settings');

--- a/src/pages/calc.tsx
+++ b/src/pages/calc.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { clsx } from 'clsx';
 import { useNavigate, useParams } from 'react-router';
 import currency from 'currency.js';
-import { Icon } from '../icons/icon';
-import { useDefaultPartySize, useDefaultTipPercent } from '../settings';
-import { billFromUrlParam, toCurrency, toNumber } from '../utils';
-import { BrandButton } from '../shared/brand-button';
-import { NumericInput } from '../shared/numeric-input';
-import { useTipCalculator } from '../use-tip-calculator';
+import { Icon } from '#/src/icons/icon';
+import { useDefaultPartySize, useDefaultTipPercent } from '#/src/settings';
+import { billFromUrlParam, toCurrency, toNumber } from '#/src/utils';
+import { BrandButton } from '#/src/shared/brand-button';
+import { NumericInput } from '#/src/shared/numeric-input';
+import { useTipCalculator } from '#/src/use-tip-calculator';
 
 export function CalcPage() {
   const params = useParams();

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router';
-import { billToUrlParam, toCurrency } from '../utils';
-import { BrandButton } from '../shared/brand-button';
-import { NumericInput } from '../shared/numeric-input';
+import { billToUrlParam, toCurrency } from '#/src/utils';
+import { BrandButton } from '#/src/shared/brand-button';
+import { NumericInput } from '#/src/shared/numeric-input';
 
 export function HomePage() {
   const navigate = useNavigate();

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -6,9 +6,9 @@ import {
   appDefaultTipPercent,
   useDefaultPartySize,
   useDefaultTipPercent,
-} from '../settings';
-import { NumericInput } from '../shared/numeric-input';
-import { BrandButton } from '../shared/brand-button';
+} from '#/src/settings';
+import { NumericInput } from '#/src/shared/numeric-input';
+import { BrandButton } from '#/src/shared/brand-button';
 
 export function SettingsPage() {
   const navigate = useNavigate();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "#/*": ["./*"]
+    }
   }
 }


### PR DESCRIPTION
This pull request introduces a new import alias configuration and updates all internal imports to use this alias, improving code consistency and maintainability. Additionally, it adjusts the `private` field placement in `package.json`.

**Import alias configuration and usage:**

* Added an `imports` field to `package.json` to define the `#/*` alias for project root imports, enabling cleaner and more robust internal import paths.
* Updated all internal imports in `src/core/footer.tsx`, `src/core/header.tsx`, `src/pages/calc.tsx`, `src/pages/home.tsx`, and `src/pages/settings.tsx` to use the new `#/*` alias instead of relative paths. [[1]](diffhunk://#diff-f8817702b0a177e2b7ee4d7e2331ef68df3e5fa0242689b601959c181215d5c5L2-R2) [[2]](diffhunk://#diff-067f4b09a95a4e0f3b09900224d1817a25574baef389313b8c472a6fbac019ddL3-R4) [[3]](diffhunk://#diff-153571ec64cf12bc64a428dda71faabb14373022ae14fade4eee4dd7ac20edb2L5-R10) [[4]](diffhunk://#diff-7c8d28ff1de800f1a1770a7f9bf600faa23af4ef36b2b27e7af3cc0b4b473ff4L3-R5) [[5]](diffhunk://#diff-6d177b9682b0b471f8605604f08a4a9265f82bd4c2d861969727cf1fdb4a9bc7L9-R11)

**Package configuration:**

* Moved the `"private": true` field to the top of `package.json` to comply with standard formatting. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R3-R9) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30)