### PR TITLE
ci: trigger production deploy on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,4 +151,4 @@ jobs:
     if: needs.release.outputs.release_created == 'true'
     steps:
       - name: 🚀 Trigger Netlify Deploy
-        run: curl -X POST ${{ secrets.NETLIFY_DEPLOY_HOOK }}
+        run: curl -fsSL -X POST ${{ secrets.NETLIFY_DEPLOY_HOOK }}


### PR DESCRIPTION
This pull request updates the CI workflow configuration to automate deployment when a new release is created. The main change is the addition of a new deploy job that triggers a Netlify deployment only if a release was created in the previous step.

**Release and deployment automation:**

* Added an `outputs` section to the `release` job to expose the `release_created` output from the `release-please-action` step. (`.github/workflows/ci.yml`)
* Introduced a new `deploy` job that depends on the `release` job and runs only if a release was created, triggering a Netlify deploy via a webhook. (`.github/workflows/ci.yml`)

> [!NOTE]
> I changed the production branch in the Netlify UI to some fake branch so it wouldn't deploy `main` to prod.